### PR TITLE
fixed firewall attachment to prevent failing when you reduce the server count   

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -311,7 +311,7 @@ resource "hcloud_firewall" "default" {
 
 resource "hcloud_firewall_attachment" "fw_ref" {
   firewall_id = hcloud_firewall.default.id
-  server_ids  = [for server in hcloud_server.main : server.id]
+  label_selectors  = ["nomad-server", "nomad-client"]
 }
 
 resource "hcloud_load_balancer" "app_load_balancer" {

--- a/nomad/main.tf
+++ b/nomad/main.tf
@@ -3,11 +3,6 @@ provider "nomad" {
   secret_id = trimspace(file("../certs/nomad_token"))
 }
 
-locals {
-  NOMAD_PORT_http = "80"
-  NOMAD_IP_http   = "10.0.0.3"
-}
-
 resource "nomad_job" "demo-webapp" {
   depends_on = [
     nomad_job.traefik
@@ -17,7 +12,7 @@ job "demo-webapp" {
   datacenters = ["dc1"]
 
   group "demo" {
-    count = 4
+    count = 1
 
     network {
       port  "http"{


### PR DESCRIPTION
fixing the usage of firewall attachment to prevent fails on downscaling